### PR TITLE
Add run on repl.it badge to README

### DIFF
--- a/.replit
+++ b/.replit
@@ -1,0 +1,2 @@
+language = "ruby"
+run = "./bin/anime_finder"

--- a/README.md
+++ b/README.md
@@ -41,3 +41,6 @@ The gem is available as open source under the terms of the [MIT License](https:/
 ## Code of Conduct
 
 Everyone interacting in the AnimeFinder project’s codebases, issue trackers, chat rooms and mailing lists is expected to follow the [code of conduct](https://github.com/'candescent-cable-3590'/anime_finder/blob/master/CODE_OF_CONDUCT.md).
+
+#Repl.it
+[![Run on Repl.it](https://repl.it/badge/github/CatheryneS/anime_finder)](https://repl.it/github/CatheryneS/anime_finder)


### PR DESCRIPTION
This pull request adds a `Run on Repl.it` badge to the `README`. This will allow users to easily run this repository in their browser, without having to set up an environment. You can learn more about Repl.it [here](https://repl.it).